### PR TITLE
Declare api_ready_poll

### DIFF
--- a/plugins/youtube_embed/assets/youtube_embed.js
+++ b/plugins/youtube_embed/assets/youtube_embed.js
@@ -135,6 +135,7 @@ hd.registerPlugin('YoutubeEmbed', function(key, shadow_root, initial_props) {
 
     }
     if (typeof YT === 'undefined' || !YT.Player) {
+        let api_ready_poll;
 
         if (!document.querySelector("script[src='https://www.youtube.com/iframe_api']")) {
             tag = document.createElement('script')


### PR DESCRIPTION
Without this declaration it looks like the timeout is never cleared and `onYouTubeIframeAPIReady` runs repeatedly forever.