### PR TITLE
Scroll fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,8 +27,9 @@ def main():
         )
 
     login_if_token_available_on_page_load()
-
-    view_app()
+    with hd.scope(hd.location().path):
+        with hd.box(height="100vh", vertical_scroll=True):
+            view_app()
 
 
 index_page = hd.index_page(

--- a/views/index.py
+++ b/views/index.py
@@ -35,7 +35,7 @@ def view_app():
     ):
         oauth_button()
 
-    with hd.vbox(align="center", gap=3, min_height="100vh"):
+    with hd.vbox(align="center", gap=3, grow=1):
         with hd.box(align="center", background_color="neutral-100"):
             image_with_aspect_ratio(
                 src="/assets/banner-transparent.webp",
@@ -70,15 +70,15 @@ def view_app():
                         hd.link(
                             lnk["label"],
                             href=lnk["href"],
-                            font_color="neutral-800"
-                            if active
-                            else "neutral-650"
-                            if active
-                            else "neutral-700",
+                            font_color=(
+                                "neutral-800"
+                                if active
+                                else "neutral-650" if active else "neutral-700"
+                            ),
                             font_size="medium",
                             padding=(0.65, 1.25, 0.25, 1.25),
                             background_color="neutral-0" if active else "neutral-100",
-                            border_radius=("6px", "6px", 0, 0) if active else 0
+                            border_radius=("6px", "6px", 0, 0) if active else 0,
                             # border_bottom=f"2px solid {'primary' if active else 'neutral-100'}",
                         )
 

--- a/views/song.py
+++ b/views/song.py
@@ -42,8 +42,6 @@ def song_view(vid_plus_song_key):
         excerpt_candidates_per_reaction[candidate["reaction_id"]].append(candidate)
         total_excerpt_candidates += 1
 
-    hd.anchor("start")
-
     window_width = hd.window().width
     if window_width > 810:
         base_width = 750
@@ -105,9 +103,9 @@ def song_view(vid_plus_song_key):
                         hd.markdown(
                             production_notes or "_no production notes added_",
                             # font_size="small",
-                            font_color="neutral-950"
-                            if production_notes
-                            else "neutral-600",
+                            font_color=(
+                                "neutral-950" if production_notes else "neutral-600"
+                            ),
                             max_width=f"{video_width}px",
                         )
                         if IsAdmin():

--- a/views/songs.py
+++ b/views/songs.py
@@ -73,7 +73,7 @@ def songs():
 def song_item(song, open=False):
     production_notes = song.get("production_notes", None)
     state = hd.state(editing_production_notes=False)
-    href = f"/help_with_concerts/{song['vid']}-{urllib.parse.quote(song['song_key'])}#start"
+    href = f"/help_with_concerts/{song['vid']}-{urllib.parse.quote(song['song_key'])}"
     # href = f"help_with_concerts?selected_song={song['vid']}"
 
     GetExcerptCandidates = asides_for_song(song["song_key"], new_task=True)
@@ -123,9 +123,9 @@ def song_item(song, open=False):
                             hd.text(
                                 production_notes or "_no production notes added_",
                                 font_size="small",
-                                font_color="neutral-950"
-                                if production_notes
-                                else "neutral-600",
+                                font_color=(
+                                    "neutral-950" if production_notes else "neutral-600"
+                                ),
                             )
                             if IsAdmin():
                                 edit_production = hd.icon_button("pencil-square")


### PR DESCRIPTION
Try out these changes to see if they improve scrolling behavior when you move between the songs list and the song page.

Apologies for the slightly noisy diff, with `black` adding parentheses and commas in a couple places.

This PR:
* Wraps the app in a fixed-height scrolling container, within a top-level `scope` that is scoped to the location path. This causes the app to scroll within this container. Since the container is wrapped in a location `scope`, its scroll position will be remembered and restored based on location.
* Uses `grow=1` instead of `min_height=100vh` to force the banner to the bottom on pages where the content is smaller than the window height. I think previously, the banner was rendered off-screen on low-content pages. Also, min_height=100vh on this container causes weird behavior when the parent has height=100vh -- the banner is stuck at 100vh regardless of whether the div with min_height=100vh is larger than 100vh. This is flexbox/min-height stuff I don't understand clearly, but I think `grow=1` is the more canonical fix to make the banner visibly stick to the bottom on low-content pages.
* Removes the `#start` anchor.

I think fixing the 'scroll to anchor' bug would/should also achieve the desired behavior of scrolling to top when clicking a song, and maybe you want to wait for that fix instead of using this PR.